### PR TITLE
Fixed path to dependencies, added option to specify tag in checkout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:latest
 
+ARG COPTER_TAG=Copter-4.0.3
+
 # install git 
 RUN apt-get update && apt-get install -y git
 
@@ -8,7 +10,7 @@ RUN git clone https://github.com/ArduPilot/ardupilot.git ardupilot
 WORKDIR ardupilot
 
 # Checkout the latest Copter...
-RUN git checkout Copter-4.0.3
+RUN git checkout ${COPTER_TAG}
 
 # Now start build instructions from http://ardupilot.org/dev/docs/setting-up-sitl-on-linux.html
 RUN git submodule update --init --recursive

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,14 @@
 FROM ubuntu:latest
-LABEL maintainer Kyle Usbeck
 
-# Need Git to checkout our sources
+# install git 
 RUN apt-get update && apt-get install -y git
 
 # Now grab ArduPilot from GitHub
 RUN git clone https://github.com/ArduPilot/ardupilot.git ardupilot
 WORKDIR ardupilot
 
-# Checkout the latest Copter... maybe we can parameterize this?
-RUN git checkout Copter-3.6.7
+# Checkout the latest Copter...
+RUN git checkout Copter-4.0.3
 
 # Now start build instructions from http://ardupilot.org/dev/docs/setting-up-sitl-on-linux.html
 RUN git submodule update --init --recursive
@@ -22,7 +21,7 @@ RUN apt-get install -y sudo lsb-release tzdata
 
 # Need USER set so usermod does not fail...
 # Install all prerequisites now
-RUN USER=nobody Tools/scripts/install-prereqs-ubuntu.sh -y
+RUN USER=nobody Tools/environment_install/install-prereqs-ubuntu.sh -y
 
 # Continue build instructions from https://github.com/ArduPilot/ardupilot/blob/master/BUILD.md
 RUN ./waf distclean

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ If you'd rather build the docker image yourself:
 You can now use the `--build-arg` option to specify which branch or tag in the ardupilot
 repository you'd like to use. Here's an example:
 
-`docker build --tag --build-arg COPTER_TAG=Copter-4.0.1 ardupilot github.com/radarku/ardupilot-sitl-docker`
+`docker build --tag ardupilot --build-arg COPTER_TAG=Copter-4.0.1 github.com/radarku/ardupilot-sitl-docker`
 
-If no COPTER_TAG is supplied, the build will use the default, current set at Copter-4.0.3
+If no COPTER_TAG is supplied, the build will use the default defined in the Dockerfile, currently set at Copter-4.0.3
 
 To run the image:
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ If you'd rather build the docker image yourself:
 
 `docker build --tag ardupilot github.com/radarku/ardupilot-sitl-docker`
 
+You can now use the `--build-arg` option to specify which branch or tag in the ardupilot
+repository you'd like to use. Here's an example:
+
+`docker build --tag --build-arg COPTER_TAG=Copter-4.0.1 ardupilot github.com/radarku/ardupilot-sitl-docker`
+
+If no COPTER_TAG is supplied, the build will use the default, current set at Copter-4.0.3
+
 To run the image:
 
 `docker run -it --rm -p 5760:5760 ardupilot`


### PR DESCRIPTION
Used your script to build a new image for SITL, but had to change the path to the dependency script and update checkout to recent version (Copter-4.0.3). Copter-3.6.7 was failing, the PX4 firmware wasn't available for download. While doing that, I noticed in your issues that you wanted an option to specify tag for checkout, so I added it as a build-arg.