### PR TITLE
docs: add docker-compose usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ https://hub.docker.com/r/radarku/ardupilot-sitl
 - To use it with [Docker Compose](https://docs.docker.com/compose/), add the following service to your `docker-compose.yml` file:
     - You can launch it with `docker-compose up -d`
     - If you update your `docker-compose.yml`, you can restart your container by running `docker-compose up -d` without getting the container ID and killing the container manually. See https://github.com/radarku/ardupilot-sitl-docker/issues/3
+    - To check the logs in `ArduCopter.log`, run `docker exec -it "$FOLDER_NAME_ardupilot-sitl_1" watch -n 1 "cat /tmp/ArduCopter.log"`, where you should update `$FOLDER_NAME` with the folder containing the `docker-compose.yml`.
 
 ```yml
 services:

--- a/README.md
+++ b/README.md
@@ -10,14 +10,21 @@ A pre-built Docker image is available on DockerHub at:
 
 https://hub.docker.com/r/radarku/ardupilot-sitl
 
-To download it, simply:
+- To download it, run `docker pull radarku/ardupilot-sitl`
+- To run it, run `docker run -it --rm -p 5760:5760 radarku/ardupilot-sitl`
+- To use it with [Docker Compose](https://docs.docker.com/compose/), add the following service to your `docker-compose.yml` file:
+    - You can launch it with `docker-compose up -d`
+    - If you update your `docker-compose.yml`, you can restart your container by running `docker-compose up -d` without getting the container ID and killing the container manually. See https://github.com/radarku/ardupilot-sitl-docker/issues/3
 
-`docker pull radarku/ardupilot-sitl`
- 
-and to run it:
-
-`docker run -it --rm -p 5760:5760 radarku/ardupilot-sitl`
-
+```yml
+services:
+  ardupilot-sitl:
+    image: radarku/ardupilot-sitl
+    platform: linux/amd64
+    tty: true
+    ports:
+      - 5760:5760
+```
 
 Quick Start
 -----------


### PR DESCRIPTION
Docker Compose makes running the container and restarting it quite convenient. That's what I use whenever I use docker for projects. IMHO, it also helps other developers get started more easily.