### PR TITLE
Force Git to use HTTPS with GitHub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:18.04
 ARG COPTER_TAG=Copter-4.0.3
 
 # install git 
-RUN apt-get update && apt-get install -y git
+RUN apt-get update && apt-get install -y git; git config --global url."https://github.com/".insteadOf git://github.com/
 
 # Now grab ArduPilot from GitHub
 RUN git clone https://github.com/ArduPilot/ardupilot.git ardupilot


### PR DESCRIPTION
Issue: https://github.com/radarku/ardupilot-sitl-docker/issues/10

Fix:
Add the following to the Dockerfile after installing Git...
`RUN git config --global url."https://github.com/".insteadOf git://github.com/`

Reason:
GitHub depricated unauthenticated Git protocol on port 9418. Apparently, the Ubuntu 18.04 repo uses a depricated Git config.
https://github.community/t/cant-show-pull-the-unauthenticated-git-protocol-on-port-9418-is-no-longer-supported/242962