### PR TITLE
simplify docker image creation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,13 @@
-FROM ubuntu:20.04
+FROM ardupilot/ardupilot-dev-base
 
-ARG COPTER_TAG=ArduPilot-4.6
+ARG COPTER_TAG=Copter-4.5.7
 
 # install git 
 RUN apt-get update && apt-get install -y git; git config --global url."https://github.com/".insteadOf git://github.com/
 
-# Trick to get apt-get to not prompt for timezone in tzdata
-ENV DEBIAN_FRONTEND=noninteractive
-RUN ln -fs /usr/share/zoneinfo/Etc/UTC /etc/localtime
-
-# Need sudo and lsb-release for the installation prerequisites
-RUN apt-get install -y sudo lsb-release tzdata
-
-# Create the user and add to sudo group
-RUN useradd --create-home --shell /bin/bash atlas \
- && usermod -aG sudo atlas \
- && echo 'atlas ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
-
- # Trick to get keyboard selection to not come up
-RUN echo 'keyboard-configuration  keyboard-configuration/layoutcode select us' | sudo debconf-set-selections && \
-echo 'keyboard-configuration  keyboard-configuration/modelcode select pc105' | sudo debconf-set-selections && \
-sudo apt-get install keyboard-configuration -y
-
-USER atlas
-WORKDIR /home/atlas
-
 # Now grab ArduPilot from GitHub
 RUN git clone https://github.com/ArduPilot/ardupilot.git ardupilot
-WORKDIR /home/atlas/ardupilot
+WORKDIR ardupilot
 
 # Checkout the latest Copter...
 RUN git checkout ${COPTER_TAG}
@@ -35,19 +15,20 @@ RUN git checkout ${COPTER_TAG}
 # Now start build instructions from http://ardupilot.org/dev/docs/setting-up-sitl-on-linux.html
 RUN git submodule update --init --recursive
 
-# Install all prerequisites now
-RUN USER=atlas DEBIAN_FRONTEND=noninteractive Tools/environment_install/install-prereqs-ubuntu.sh -y
+# Trick to get apt-get to not prompt for timezone in tzdata
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Need sudo and lsb-release for the installation prerequisites
+RUN apt-get install -y sudo lsb-release tzdata
 
 # Continue build instructions from https://github.com/ArduPilot/ardupilot/blob/master/BUILD.md
 RUN ./waf distclean
 RUN ./waf configure --board sitl
 RUN ./waf copter
-RUN ./waf rover 
-RUN ./waf plane
-RUN ./waf sub
 
 # TCP 5760 is what the sim exposes by default
 EXPOSE 5760/tcp
+EXPOSE 14550/udp
 
 # Variables for simulator
 ENV INSTANCE 0
@@ -58,10 +39,10 @@ ENV DIR 270
 ENV MODEL +
 ENV SPEEDUP 1
 ENV VEHICLE ArduCopter
+ENV PATH="/usr/local/bin:/root/.local/bin:${PATH}"
 
-#install maxproxy
-RUN python3 -m pip install PyYAML mavproxy --user
-ENV PATH="${PATH}:/home/atlas/.local/bin"
+RUN pip3 install --no-cache-dir MAVProxy pymavlink # Install MAVProxy
 
 # Finally the command
-ENTRYPOINT Tools/autotest/sim_vehicle.py --vehicle ${VEHICLE} -I${INSTANCE} --custom-location=${LAT},${LON},${ALT},${DIR} -w --frame ${MODEL} --no-rebuild --speedup ${SPEEDUP}
+ENV SITL_UDP_OUTPUT_ADDRESS udp:127.0.0.1:14550
+ENTRYPOINT /ardupilot/Tools/autotest/sim_vehicle.py --vehicle ${VEHICLE} -I${INSTANCE} --custom-location=${LAT},${LON},${ALT},${DIR} -w --frame ${MODEL} --no-rebuild --speedup ${SPEEDUP} --out ${SITL_UDP_OUTPUT_ADDRESS}


### PR DESCRIPTION
### 🔧 What was done

- Rewritten Dockerfile: replaced the base image `ubuntu:20.04` with `ardupilot/ardupilot-dev-base`.
- Removed redundant setup steps (e.g., `install-prereqs-ubuntu.sh`, timezone, keyboard config).
- Simplified the overall configuration process.
- Compiled only the `copter` target (removed `rover`, `plane`, `sub` to reduce build time).
- Installed `MAVProxy` globally using pip.
- Updated `ENTRYPOINT` to include the `--out` argument for correct MAVProxy communication.

### 🎯 Purpose of this PR

This change was made while working on my own project  
👉 [`ardupilot-sitl-unity`](https://github.com/stnslv-bugaev/ardupilot-sitl-unity.git),  
which aims to simulate a drone environment using ArduPilot SITL integrated with Unity.

The goal of this PR is to simplify and optimize the Docker-based setup for SITL, making it easier to integrate with external systems like Unity, by:
- Reducing unnecessary dependencies and build steps,
- Using a pre-configured development base image,
- Ensuring stable communication with MAVProxy out of the box.

### 🐳 Example run command

```bash
docker run -it --rm --env SITL_UDP_OUTPUT_ADDRESS=udp:host.docker.internal:14550 ardupilot
```

This command runs the SITL container and forwards MAVLink telemetry via UDP port 14550 to the host, which can be consumed by the Unity project or other clients.

### ✅ What was tested

- Image builds successfully using `docker build`.
- Simulator starts and binds to TCP 5760 / UDP 14550.
- MAVProxy connects correctly to the SITL instance.

### 📌 Additional notes

It might be useful in the future to externalize simulation parameters (LAT, LON, etc.) using environment variables or a `docker-compose` setup for better flexibility across projects.
